### PR TITLE
Adding wrapper for console.info

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -169,6 +169,8 @@
 				hdlr = console.warn;
 			} else if (context.level === Logger.ERROR && console.error) {
 				hdlr = console.error;
+			} else if (context.level === Logger.INFO && console.info) {
+				hdlr = console.info;
 			}
 
 			hdlr.apply(console, messages);


### PR DESCRIPTION
There are `console.warn` and `console.error` wrappers, but no `console.info`.
When console environments support console.info, use that instead of console.log
