### PR TITLE
IE 8 patch

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -173,7 +173,12 @@
 				hdlr = console.info;
 			}
 
-			hdlr.apply(console, messages);
+			try {
+				hdlr.apply(console, messages);
+			} catch(e) {
+				// IE 8 console methods do not inherit from Function, and thus do not possess .apply() or .call()
+				Function.prototype.call.apply(hdlr, messages);
+			}
 		});
 	};
 


### PR DESCRIPTION
IE 8 window.console.info, log, error, warn do not inherit from Function, and thus lack .apply() or .call().
