### PR TITLE
Add method to get default handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ logFormatter function which can alter the messages printed to the console:
 		}
 	})
 
+In order to get the default log handler function, you may call `Logger.getDefaultHandler()`.
+
 ## Named Loggers
 Okay, let's get serious, logging is not for kids, it's for adults with serious software to write and mission critical log messages to trawl through.  To help you in your goal, js-Logger provides 'named' loggers which can be configured individual with their own contexts.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "js-logger",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "src/logger.js",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "js-logger-aknudsen",
+  "name": "js-logger",
   "version": "1.3.0",
   "description": "Lightweight, unobtrusive, configurable JavaScript logger",
   "author": "Jonny Reeves (http://jonnyreeves.co.uk), Arve Knudsen (http://arveknudsen.com)",
-  "homepage": "http://github.com/aknuds1/js-logger",
+  "homepage": "http://github.com/jonnyreeves/js-logger",
   "repository": {
     "type": "git",
-    "url": "git://github.com/aknuds1/js-logger.git"
+    "url": "git://github.com/jonnyreeves/js-logger.git"
   },
   "bugs": {
-    "url": "http://github.com/aknuds1/js-logger/issues"
+    "url": "http://github.com/jonnyreeves/js-logger/issues"
   },
   "license": "MIT",
   "main": "src/logger.js",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,17 @@
 {
-  "name": "js-logger",
-  "version": "1.2.0",
+  "name": "js-logger-aknudsen",
+  "version": "1.3.0",
   "description": "Lightweight, unobtrusive, configurable JavaScript logger",
-  "author": "Jonny Reeves (http://jonnyreeves.co.uk)",
-  "homepage": "http://github.com/jonnyreeves/js-logger",
+  "author": "Jonny Reeves (http://jonnyreeves.co.uk), Arve Knudsen (http://arveknudsen.com)",
+  "homepage": "http://github.com/aknuds1/js-logger",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jonnyreeves/js-logger.git"
+    "url": "git://github.com/aknuds1/js-logger.git"
   },
   "bugs": {
-    "url": "http://github.com/jonnyreeves/js-logger/issues"
+    "url": "http://github.com/aknuds1/js-logger/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/jonnyreeves/js-logger/blob/master/MIT-LICENSE.txt"
-    }
-  ],
+  "license": "MIT",
   "main": "src/logger.js",
   "scripts": {
     "test": "gulp test lint"

--- a/src/logger.js
+++ b/src/logger.js
@@ -10,7 +10,7 @@
 	var Logger = { };
 
 	// For those that are at home that are keeping score.
-	Logger.VERSION = "1.2.0";
+	Logger.VERSION = "1.3.0";
 
 	// Function which handles all incoming log messages.
 	var logHandler;
@@ -162,6 +162,9 @@
 
 		var hdlr = console.log;
 		var timerLabel;
+		// Map of timestamps by timer labels used to track `#time` and `#timeEnd()` invocations in environments
+		// that don't offer a native console method.
+		var timerStartTimeByLabelMap = {};
 
 		if (context.level === Logger.TIME) {
 			timerLabel = (context.name ? '[' + context.name + '] ' : '') + messages[0];
@@ -197,7 +200,7 @@
 			Logger._options.formatter(messages, context);
 			invokeConsoleMethod(hdlr, messages);
 		}
-	}
+	};
 
 	Logger.getDefaultHandler = function() {
 		return defaultHandler;
@@ -228,10 +231,6 @@
 		if (typeof console === "undefined") {
 			return;
 		}
-
-		// Map of timestamps by timer labels used to track `#time` and `#timeEnd()` invocations in environments
-		// that don't offer a native console method.
-		var timerStartTimeByLabelMap = {};
 
 		Logger.setLevel(options.defaultLevel || Logger.DEBUG);
 		Logger.setHandler(defaultHandler);

--- a/src/logger.js
+++ b/src/logger.js
@@ -157,6 +157,9 @@
 			Function.prototype.apply.call(hdlr, console, messages);
 		};
 
+		Logger._options = Logger._options || {};
+		var options = Logger._options;
+
 		// Convert arguments object to Array.
 		messages = Array.prototype.slice.call(messages);
 
@@ -197,7 +200,13 @@
 				hdlr = console.info;
 			}
 
-			Logger._options.formatter(messages, context);
+			options.formatter = options.formatter || function defaultMessageFormatter(messages, context) {
+				// Prepend the logger's name to the log message for easy identification.
+				if (context.name) {
+					messages.unshift("[" + context.name + "]");
+				}
+			};
+			options.formatter(messages, context);
 			invokeConsoleMethod(hdlr, messages);
 		}
 	};
@@ -219,13 +228,6 @@
 	Logger.useDefaults = function(options) {
 		options = options || {};
 		Logger._options = options;
-
-		options.formatter = options.formatter || function defaultMessageFormatter(messages, context) {
-			// Prepend the logger's name to the log message for easy identification.
-			if (context.name) {
-				messages.unshift("[" + context.name + "]");
-			}
-		};
 
 		// Check for the presence of a logger.
 		if (typeof console === "undefined") {

--- a/src/logger.js
+++ b/src/logger.js
@@ -151,6 +151,58 @@
 		}
 	};
 
+	var defaultHandler = function(messages, context) {
+		// Support for IE8+ (and other, slightly more sane environments)
+		var invokeConsoleMethod = function (hdlr, messages) {
+			Function.prototype.apply.call(hdlr, console, messages);
+		};
+
+		// Convert arguments object to Array.
+		messages = Array.prototype.slice.call(messages);
+
+		var hdlr = console.log;
+		var timerLabel;
+
+		if (context.level === Logger.TIME) {
+			timerLabel = (context.name ? '[' + context.name + '] ' : '') + messages[0];
+
+			if (messages[1] === 'start') {
+				if (console.time) {
+					console.time(timerLabel);
+				}
+				else {
+					timerStartTimeByLabelMap[timerLabel] = new Date().getTime();
+				}
+			}
+			else {
+				if (console.timeEnd) {
+					console.timeEnd(timerLabel);
+				}
+				else {
+					invokeConsoleMethod(hdlr, [ timerLabel + ': ' +
+						(new Date().getTime() - timerStartTimeByLabelMap[timerLabel]) + 'ms' ]);
+				}
+			}
+		}
+		else {
+			// Delegate through to custom warn/error loggers if present on the console.
+			if (context.level === Logger.WARN && console.warn) {
+				hdlr = console.warn;
+			} else if (context.level === Logger.ERROR && console.error) {
+				hdlr = console.error;
+			} else if (context.level === Logger.INFO && console.info) {
+				hdlr = console.info;
+			}
+
+			Logger._options.formatter(messages, context);
+			invokeConsoleMethod(hdlr, messages);
+		}
+	}
+
+	Logger.getDefaultHandler = function() {
+		return defaultHandler;
+	};
+
 	// Retrieve a ContextualLogger instance.  Note that named loggers automatically inherit the global logger's level,
 	// default context and log handler.
 	Logger.get = function (name) {
@@ -163,6 +215,7 @@
 	// `options` hash can be used to configure the default logLevel and provide a custom message formatter.
 	Logger.useDefaults = function(options) {
 		options = options || {};
+		Logger._options = options;
 
 		options.formatter = options.formatter || function defaultMessageFormatter(messages, context) {
 			// Prepend the logger's name to the log message for easy identification.
@@ -180,54 +233,8 @@
 		// that don't offer a native console method.
 		var timerStartTimeByLabelMap = {};
 
-		// Support for IE8+ (and other, slightly more sane environments)
-		var invokeConsoleMethod = function (hdlr, messages) {
-			Function.prototype.apply.call(hdlr, console, messages);
-		};
-
 		Logger.setLevel(options.defaultLevel || Logger.DEBUG);
-		Logger.setHandler(function(messages, context) {
-			// Convert arguments object to Array.
-			messages = Array.prototype.slice.call(messages);
-
-			var hdlr = console.log;
-			var timerLabel;
-
-			if (context.level === Logger.TIME) {
-				timerLabel = (context.name ? '[' + context.name + '] ' : '') + messages[0];
-
-				if (messages[1] === 'start') {
-					if (console.time) {
-						console.time(timerLabel);
-					}
-					else {
-						timerStartTimeByLabelMap[timerLabel] = new Date().getTime();
-					}
-				}
-				else {
-					if (console.timeEnd) {
-						console.timeEnd(timerLabel);
-					}
-					else {
-						invokeConsoleMethod(hdlr, [ timerLabel + ': ' +
-							(new Date().getTime() - timerStartTimeByLabelMap[timerLabel]) + 'ms' ]);
-					}
-				}
-			}
-			else {
-				// Delegate through to custom warn/error loggers if present on the console.
-				if (context.level === Logger.WARN && console.warn) {
-					hdlr = console.warn;
-				} else if (context.level === Logger.ERROR && console.error) {
-					hdlr = console.error;
-				} else if (context.level === Logger.INFO && console.info) {
-					hdlr = console.info;
-				}
-
-				options.formatter(messages, context);
-				invokeConsoleMethod(hdlr, messages);
-			}
-		});
+		Logger.setHandler(defaultHandler);
 	};
 
 	// Export to popular environments boilerplate.

--- a/test-src/loggertests.js
+++ b/test-src/loggertests.js
@@ -215,4 +215,9 @@
 		assert.ok(formatterSpy.firstCall.args[1].name === 'Dave',
 			'Context passed to formatter');
 	});
+
+	QUnit.test('Logger.getDefaultHandler returns default log handler', function (assert) {
+		var defaultHandler = this.logger.getDefaultHandler();
+		assert.equal(typeof defaultHandler, 'function');
+	});
 }());


### PR DESCRIPTION
I needed a Logger method to get the default handler, so that I could insert a handler that just wraps the default one. For some reason every line of logger.js gets changed, although I don't know why. It must be whitespace differences.

I wrote a test to verify the new method (getDefaultHandler).