### PR TITLE
Added logger.d.ts for Typescript / Angular usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "js-logger",
-  "version": "1.2.0",
+  "name": "js-logger-pjsb",
+  "version": "1.3.0",
   "description": "Lightweight, unobtrusive, configurable JavaScript logger",
   "author": "Jonny Reeves (http://jonnyreeves.co.uk)",
   "homepage": "http://github.com/jonnyreeves/js-logger",
+  "typings": "./src/logger.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/jonnyreeves/js-logger.git"

--- a/pakmanaged.js
+++ b/pakmanaged.js
@@ -1,0 +1,85 @@
+var global = Function("return this;")();
+/*!
+  * Ender: open module JavaScript framework (client-lib)
+  * copyright Dustin Diaz & Jacob Thornton 2011 (@ded @fat)
+  * http://ender.no.de
+  * License MIT
+  */
+!function (context) {
+
+  // a global object for node.js module compatiblity
+  // ============================================
+
+  context['global'] = context
+
+  // Implements simple module system
+  // losely based on CommonJS Modules spec v1.1.1
+  // ============================================
+
+  var modules = {}
+    , old = context.$
+
+  function require (identifier) {
+    // modules can be required from ender's build system, or found on the window
+    var module = modules[identifier] || window[identifier]
+    if (!module) throw new Error("Requested module '" + identifier + "' has not been defined.")
+    return module
+  }
+
+  function provide (name, what) {
+    return (modules[name] = what)
+  }
+
+  context['provide'] = provide
+  context['require'] = require
+
+  function aug(o, o2) {
+    for (var k in o2) k != 'noConflict' && k != '_VERSION' && (o[k] = o2[k])
+    return o
+  }
+
+  function boosh(s, r, els) {
+    // string || node || nodelist || window
+    if (typeof s == 'string' || s.nodeName || (s.length && 'item' in s) || s == window) {
+      els = ender._select(s, r)
+      els.selector = s
+    } else els = isFinite(s.length) ? s : [s]
+    return aug(els, boosh)
+  }
+
+  function ender(s, r) {
+    return boosh(s, r)
+  }
+
+  aug(ender, {
+      _VERSION: '0.3.6'
+    , fn: boosh // for easy compat to jQuery plugins
+    , ender: function (o, chain) {
+        aug(chain ? boosh : ender, o)
+      }
+    , _select: function (s, r) {
+        return (r || document).querySelectorAll(s)
+      }
+  })
+
+  aug(boosh, {
+    forEach: function (fn, scope, i) {
+      // opt out of native forEach so we can intentionally call our own scope
+      // defaulting to the current item and be able to return self
+      for (i = 0, l = this.length; i < l; ++i) i in this && fn.call(scope || this[i], this[i], i, this)
+      // return self for chaining
+      return this
+    },
+    $: ender // handy reference to self
+  })
+
+  ender.noConflict = function () {
+    context.$ = old
+    return this
+  }
+
+  if (typeof module !== 'undefined' && module.exports) module.exports = ender
+  // use subscript notation as extern for Closure compilation
+  context['ender'] = context['$'] = context['ender'] || ender
+
+}(this);

--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @module
+ * @description
+ * Starting point to import logger API.
+ */
+
+interface ILogger {
+    useDefaults(): void;
+    debug(x: any): void;
+    info(x: any): void;
+    warn(x: any): void;
+    error(x: any): void;
+    setLevel(x: any): void;
+    setHandler(x: any): void;
+    get(x: any): any;
+    time(x: any): void;
+    timeEnd(x: any): void;
+  }
+
+declare var Logger: ILogger;
+export = Logger;


### PR DESCRIPTION
Another integration possibility added by adding typescript definition logger.d.ts.

Then the logger can be used in Import:
`import * as Logger from "js-logger-pjsb";`
respectively (if pull request is accepted and merged:
`import * as Logger from "js-logger";`