### PR TITLE
use 1-element array in console log to make it actually useful in chromium-based webviews (eg. crosswalk)

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -227,7 +227,9 @@
 				}
 
 				options.formatter(messages, context);
-				invokeConsoleMethod(hdlr, messages);
+				var msg = [];
+				msg.push(messages.join(' '));
+				invokeConsoleMethod(hdlr, msg);
 			}
 		};
 	};


### PR DESCRIPTION
Please, review this pr. I needed this to get useful log messages in cordova/crosswalk apps