### PR TITLE
fix: mandatory property formatter in useDefaults()

### DIFF
--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -41,7 +41,7 @@ interface ILoggerOpts extends Object {
    * Defines custom formatter for the log message
    * @param  {formatterCallback} callback the callback which handles the formatting
    */
-  formatter: (messages: any[], context: IContext) => void;
+  formatter?: (messages: any[], context: IContext) => void;
 }
 
 /**


### PR DESCRIPTION
`formatter` is erroneously mandatory in `ILoggerOpts`.