### PR TITLE
Adding trace method using console.trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Logger.debug("I'm a debug message!");
 Logger.info("OMG! Check this window out!", window);
 Logger.warn("Purple Alert! Purple Alert!");
 Logger.error("HOLY SHI... no carrier.");
+Logger.trace("Very verbose message that usually is not needed...");
+Logger.trace("...containing stack trace (if console.trace() method supports it)");
 ```
 
 Log messages can get a bit annoying; you don't need to tell me, it's all cool.  If things are getting too noisy for your liking then it's time you read up on the `Logger.setLevel` method:
@@ -121,13 +123,15 @@ Logger.get('ModuleA').warn('FizzWozz combombulated!');
 Note that `Logger.setLevel()` will also change the current log filter level for all named logger instances; so typically you would configure your logger levels like so:
 
 ```js
-// Create a couple of named loggers (typically in their own module)
+// Create several named loggers (typically in their own module)
 var loggerA = Logger.get('LoggerA');
 var loggerB = Logger.get('LoggerB');
+var loggerC = Logger.get('LoggerC');
 
 // Configure log levels.
 Logger.setLevel(Logger.WARN);  // Global logging level.
 Logger.get('LoggerB').setLevel(Logger.DEBUG);  // Enable debug logging for LoggerB
+Logger.get('LoggerC').setLevel(Logger.TRACE);  // Enable trace logging for LoggerC
 ```
 
 ## Profiling

--- a/src/logger.js
+++ b/src/logger.js
@@ -44,10 +44,11 @@
 	};
 
 	// Predefined logging levels.
-	Logger.DEBUG = defineLogLevel(1, 'DEBUG');
-	Logger.INFO = defineLogLevel(2, 'INFO');
-	Logger.TIME = defineLogLevel(3, 'TIME');
-	Logger.WARN = defineLogLevel(4, 'WARN');
+	Logger.TRACE = defineLogLevel(1, 'TRACE');
+	Logger.DEBUG = defineLogLevel(2, 'DEBUG');
+	Logger.INFO = defineLogLevel(3, 'INFO');
+	Logger.TIME = defineLogLevel(4, 'TIME');
+	Logger.WARN = defineLogLevel(5, 'WARN');
 	Logger.ERROR = defineLogLevel(8, 'ERROR');
 	Logger.OFF = defineLogLevel(99, 'OFF');
 
@@ -77,6 +78,10 @@
 		enabledFor: function (lvl) {
 			var filterLevel = this.context.filterLevel;
 			return lvl.value >= filterLevel.value;
+		},
+
+		trace: function () {
+			this.invoke(Logger.TRACE, arguments);
 		},
 
 		debug: function () {
@@ -124,6 +129,7 @@
 		var L = Logger;
 
 		L.enabledFor = bind(globalLogger, globalLogger.enabledFor);
+		L.trace = bind(globalLogger, globalLogger.trace);
 		L.debug = bind(globalLogger, globalLogger.debug);
 		L.time = bind(globalLogger, globalLogger.time);
 		L.timeEnd = bind(globalLogger, globalLogger.timeEnd);
@@ -234,6 +240,8 @@
 					hdlr = console.info;
 				} else if (context.level === Logger.DEBUG && console.debug) {
 					hdlr = console.debug;
+				} else if (context.level === Logger.TRACE && console.trace) {
+					hdlr = console.trace;
 				}
 
 				options.formatter(messages, context);

--- a/test-src/loggertests.js
+++ b/test-src/loggertests.js
@@ -18,33 +18,37 @@
 		var logger = this.logger;
 
 		// Enable all log messages.
-		logger.setLevel(logger.DEBUG);
+		logger.setLevel(logger.TRACE);
 
 		// Route some messages through to the logFunc.
+		logger.trace("A trace message");
 		logger.debug("A debug message");
 		logger.info("An info message");
 		logger.warn("A warning message");
 		logger.error("An error message");
 
 		// Check they were received.
-		assert.equal(this.calls[0].messages[0], "A debug message");
-		assert.strictEqual(this.calls[0].context.level, logger.DEBUG);
+		assert.equal(this.calls[0].messages[0], "A trace message");
+		assert.strictEqual(this.calls[0].context.level, logger.TRACE);
 
-		assert.equal(this.calls[1].messages[0], "An info message");
-		assert.strictEqual(this.calls[1].context.level, logger.INFO);
+		assert.equal(this.calls[1].messages[0], "A debug message");
+		assert.strictEqual(this.calls[1].context.level, logger.DEBUG);
 
-		assert.equal(this.calls[2].messages[0], "A warning message");
-		assert.strictEqual(this.calls[2].context.level, logger.WARN);
+		assert.equal(this.calls[2].messages[0], "An info message");
+		assert.strictEqual(this.calls[2].context.level, logger.INFO);
 
-		assert.equal(this.calls[3].messages[0], "An error message");
-		assert.strictEqual(this.calls[3].context.level, logger.ERROR);
+		assert.equal(this.calls[3].messages[0], "A warning message");
+		assert.strictEqual(this.calls[3].context.level, logger.WARN);
+
+		assert.equal(this.calls[4].messages[0], "An error message");
+		assert.strictEqual(this.calls[4].context.level, logger.ERROR);
 	});
 
-	QUnit.test('Golobal Logger - Timing operations routed to logger function', function (assert) {
+	QUnit.test('Global Logger - Timing operations routed to logger function', function (assert) {
 		var logger = this.logger;
 
 		// Enable all log messages.
-		logger.setLevel(logger.DEBUG);
+		logger.setLevel(logger.TRACE);
 
 		logger.time('label');
 		assert.strictEqual(this.calls[0].context.level, logger.TIME);
@@ -61,13 +65,23 @@
 		var logger = this.logger;
 
 		logger.setLevel(logger.OFF);
+		assert.equal(logger.enabledFor(logger.TRACE), false);
 		assert.equal(logger.enabledFor(logger.DEBUG), false);
 		assert.equal(logger.enabledFor(logger.INFO), false);
 		assert.equal(logger.enabledFor(logger.TIME), false);
 		assert.equal(logger.enabledFor(logger.WARN), false);
 		assert.equal(logger.enabledFor(logger.ERROR), false);
 
+		logger.setLevel(logger.TRACE);
+		assert.equal(logger.enabledFor(logger.TRACE), true);
+		assert.equal(logger.enabledFor(logger.DEBUG), true);
+		assert.equal(logger.enabledFor(logger.INFO), true);
+		assert.equal(logger.enabledFor(logger.TIME), true);
+		assert.equal(logger.enabledFor(logger.WARN), true);
+		assert.equal(logger.enabledFor(logger.ERROR), true);
+
 		logger.setLevel(logger.DEBUG);
+		assert.equal(logger.enabledFor(logger.TRACE), false);
 		assert.equal(logger.enabledFor(logger.DEBUG), true);
 		assert.equal(logger.enabledFor(logger.INFO), true);
 		assert.equal(logger.enabledFor(logger.TIME), true);
@@ -75,6 +89,7 @@
 		assert.equal(logger.enabledFor(logger.ERROR), true);
 
 		logger.setLevel(logger.INFO);
+		assert.equal(logger.enabledFor(logger.TRACE), false);
 		assert.equal(logger.enabledFor(logger.DEBUG), false);
 		assert.equal(logger.enabledFor(logger.INFO), true);
 		assert.equal(logger.enabledFor(logger.TIME), true);
@@ -82,6 +97,7 @@
 		assert.equal(logger.enabledFor(logger.ERROR), true);
 
 		logger.setLevel(logger.WARN);
+		assert.equal(logger.enabledFor(logger.TRACE), false);
 		assert.equal(logger.enabledFor(logger.DEBUG), false);
 		assert.equal(logger.enabledFor(logger.INFO), false);
 		assert.equal(logger.enabledFor(logger.TIME), false);
@@ -89,6 +105,7 @@
 		assert.equal(logger.enabledFor(logger.ERROR), true);
 
 		logger.setLevel(logger.ERROR);
+		assert.equal(logger.enabledFor(logger.TRACE), false);
 		assert.equal(logger.enabledFor(logger.DEBUG), false);
 		assert.equal(logger.enabledFor(logger.INFO), false);
 		assert.equal(logger.enabledFor(logger.TIME), false);
@@ -119,7 +136,7 @@
 		this.logger.setLevel(Logger.OFF);
 		named.setLevel(Logger.DEBUG);
 
-		named.debug("Debug message via nemd logger");
+		named.debug("Debug message via named logger");
 		this.logger.debug("Debug message via Global Logger");
 
 		// Check the log message was routed correctly.
@@ -168,21 +185,24 @@
 		assert.strictEqual(level, Logger.DEBUG);
 	});
 
-	QUnit.test("Logger.useDefaults logs to console", function (assert) {
+	QUnit.test("Logger.useDefaults logs to console (except trace)", function (assert) {
 		var logger = this.logger;
 
 		var sandbox = sinon.sandbox.create();
+		sandbox.stub(console, "trace");
 		sandbox.stub(console, "debug");
 		sandbox.stub(console, "info");
 		sandbox.stub(console, "warn");
 		sandbox.stub(console, "error");
 
-		logger.useDefaults();
+		logger.useDefaults(); // default loglevel is debug
+		logger.trace("trace message");
 		logger.debug("debug message");
 		logger.info("info message");
 		logger.warn("warning message");
 		logger.error("error message");
 
+		assert.ok(console.trace.callCount === 0, "logger.trace calls console.trace");
 		assert.ok(console.debug.calledOnce, "logger.debug calls console.debug");
 		assert.ok(console.info.calledOnce, "logger.info calls console.info");
 		assert.ok(console.warn.calledOnce, "logger.warn calls console.warn");


### PR DESCRIPTION
Thinking to use console.trace features as well, I was deciding between where to implement them -- either in the wrapper over this library, or in the library itself.

I tend to think that idea of keeping all console low-level invocation in one place is good. Meanwhile, I understand that it may be treated as some conceptual change. So it's purely to the maintainer to decide whether the proposed PR is applicable or not.

Tried to keep external defaults and interfaces intact (except for adding additional trace method ofc).

Travis fails not due to my changes I believe.