### PR TITLE
Fix TypeScript typings for `ILoggerOpts`

### DIFF
--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -36,7 +36,8 @@ interface ILoggerOpts extends Object {
   /**
    * The log level, default is DEBUG
    */
-  logLevel?: ILogLevel;
+  defaultLevel?: ILogLevel;
+
   /**
    * Defines custom formatter for the log message
    * @param  {formatterCallback} callback the callback which handles the formatting


### PR DESCRIPTION
I can't see any usage of `logLevel` from the options, just `defaultLevel`.

Hence updating the typings.

Next the typings should probably be tested, or rather generated automatically. The library is not that big and could be converted to TS (if you're open to it) rather quickly.