### PR TITLE
Stop exporting ILogger

### DIFF
--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -2,6 +2,7 @@
  * @module js-logger
  * @description Typescript description for js-logger
  */
+
 interface ILogLevel extends Object {
   /**
    * The numerical representation of the level
@@ -51,7 +52,7 @@ interface ILoggerOpts extends Object {
  * @param  {IContext} context  the current logger context (level and name)
  */
 
-export interface ILogger {
+interface ILogger {
   DEBUG: ILogLevel;
   INFO: ILogLevel;
   TIME: ILogLevel;


### PR DESCRIPTION
Rollback of changes as it breaks with Typescript 3.1.3.

`export =` Logger prevents us from exporting anything else. ILogger should probably be defined in another file.

This should bring the definition file to the same state it was in in 1.4.1 which works well with TS 1.4.1