### PR TITLE
Improve Typings.

### DIFF
--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -1,4 +1,4 @@
-import { ILogger, ILoggerOpts, ILogLevel, IContext } from './types'
+import { GlobalLogger } from './types'
 
-declare var Logger: ILogger;
+declare var Logger: GlobalLogger;
 export = Logger;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 export interface ILogger {
+  TRACE: ILogLevel;
   DEBUG: ILogLevel;
   INFO: ILogLevel;
   TIME: ILogLevel;
@@ -6,18 +7,14 @@ export interface ILogger {
   ERROR: ILogLevel;
   OFF: ILogLevel;
 
+  trace(...x: any[]): void;
   debug(...x: any[]): void;
   info(...x: any[]): void;
   log(...x: any[]): void;
   warn(...x: any[]): void;
   error(...x: any[]): void;
-
-  /**
-   * Configure and example a Default implementation which writes to the
-   * `window.console` (if present). The `options` hash can be used to configure
-   * the default logLevel and provide a custom message formatter.
-   */
-  useDefaults(options?: ILoggerOpts): void;
+  time(label: string): void;
+  timeEnd(label: string): void;
 
   /**
    * Sets the global logging filter level which applies to *all* previously
@@ -27,12 +24,25 @@ export interface ILogger {
    * @param  {ILogLevel} level the level to switch to
    */
   setLevel(level: ILogLevel): void;
+
   /**
    * Gets the global logging filter level
    *
    * @return {ILogLevel} the current logging level
    */
   getLevel(): ILogLevel;
+
+  enabledFor(level: ILogLevel): boolean;
+}
+
+export interface GlobalLogger extends ILogger {
+  /**
+   * Configure and example a Default implementation which writes to the
+   * `window.console` (if present). The `options` hash can be used to configure
+   * the default logLevel and provide a custom message formatter.
+   */
+  useDefaults(options?: ILoggerOpts): void;
+
    /**
    * Set the global logging handler. The supplied function should
    * expect two arguments, the first being an arguments object with the
@@ -40,7 +50,8 @@ export interface ILogger {
    * contains a hash of stateful parameters which the logging function can consume.
    * @param  {setHandlerCallback} callback the callback which handles the logging
    */
-  setHandler(logHandler: (messages: any[], context: IContext) => void): void;
+  setHandler(logHandler: ILogHandler): void;
+
   /**
    * Retrieve a ContextualLogger instance.  Note that named loggers automatically
    * inherit the global logger's level, default context and log handler.
@@ -49,10 +60,17 @@ export interface ILogger {
    * @return {ILogger}      the named logger
    */
   get(name: string): ILogger;
-  time(label: string): void;
-  timeEnd(label: string): void;
-  enabledFor(level: ILogLevel): boolean;
-  createDefaultHandler(options?: ILoggerOpts): (messages: any[], context: IContext) => void;
+
+  /** 
+   * CreateDefaultHandler returns a handler function which can be passed to `Logger.setHandler()` which will
+   * write to the window's console object (if present); the optional options object can be used to customise the
+   * formatter used to format each log message.
+   */
+  createDefaultHandler(options?: CreateDefaultHandlerOptions): ILogHandler;
+}
+
+export interface ILogHandler {
+  (messages: any[], context: IContext): void
 }
 
 export interface ILogLevel extends Object {
@@ -66,7 +84,7 @@ export interface ILogLevel extends Object {
   name: string;
 }
 
-export interface IContext extends Object {
+interface IContext extends Object {
   /**
    * The currrent log level
    */
@@ -77,22 +95,11 @@ export interface IContext extends Object {
   name?: string;
 }
 
-/**
- * Defines custom formatter for the log message
- * @callback formatterCallback
- * @param  {any[]}    messages the given logger arguments
- * @param  {IContext} context  the current logger context (level and name)
- */
+interface CreateDefaultHandlerOptions {
+  formatter?: ILogHandler;
+}
 
 export interface ILoggerOpts extends Object {
-  /**
-   * The log level, default is DEBUG
-   */
   defaultLevel?: ILogLevel;
-
-  /**
-   * Defines custom formatter for the log message
-   * @param  {formatterCallback} callback the callback which handles the formatting
-   */
-  formatter?: (messages: any[], context: IContext) => void;
+  formatter?: ILogHandler;
 }


### PR DESCRIPTION
- Fixes #86 by adding the `trace()` method.
- Correctly separates the 'global logger' methods out of the ILogger interface