### PR TITLE
Export all interfaces to fix issue 'Cannot find name 'IContext'

### DIFF
--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -84,7 +84,7 @@ export interface ILogLevel extends Object {
   name: string;
 }
 
-interface IContext extends Object {
+export interface IContext extends Object {
   /**
    * The currrent log level
    */
@@ -95,7 +95,7 @@ interface IContext extends Object {
   name?: string;
 }
 
-interface CreateDefaultHandlerOptions {
+export interface CreateDefaultHandlerOptions {
   formatter?: ILogHandler;
 }
 


### PR DESCRIPTION
It needs to export IContext interface since it is referenced from ILogHandler. Attempt to define instance of ILogHandler leads to typescript complier error.